### PR TITLE
BISERVER-8671 - GwtToolbar respect the "visible" attribute when defined ...

### DIFF
--- a/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/tags/GwtToolbar.java
+++ b/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/tags/GwtToolbar.java
@@ -38,6 +38,7 @@ public class GwtToolbar extends AbstractGwtXulContainer implements XulToolbar{
   public GwtToolbar(){
     super("toolbar");
     setManagedObject(toolbar);
+    this.container = toolbar;
   }
   
   public String getToolbarName() {


### PR DESCRIPTION
...in a XUL file, defaulted PUC toolbar to not visible, added an overlay to default plugin.xml config to turn on the toolbar for the "Opened" perspective

set the container object to the toolbar, allowing the visibility attribute to be picked up and used by XUL
