### PR TITLE
Fix for BISERVER-9276  Cannot create a CSV datasource in Firefox 

### DIFF
--- a/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/tags/GwtFileUpload.java
+++ b/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/tags/GwtFileUpload.java
@@ -110,7 +110,7 @@ public class GwtFileUpload  extends AbstractGwtXulContainer implements XulFileUp
     uploadTextBox = new GwtTextbox();
     uploadTextBox.setId("gwt_FileUpload_uploadTextBox");
     uploadTextBox.setHeight(getHeight());
-    uploadTextBox.setWidth(getWidth() - 50);
+    uploadTextBox.setWidth(getWidth() - 55);
 
     GwtButton uploadButton = new GwtButton();
     uploadButton.setId("gwt_FileUpload_uploadButton");


### PR DESCRIPTION
Fix for BISERVER-9276  Cannot create a CSV datasource in Firefox 
