### PR TITLE
PDB-1545 - Dashboard printing cannot be enabled in 5.0

### DIFF
--- a/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/widgets/GwtTabWidget.java
+++ b/pentaho-xul-gwt/src/org/pentaho/ui/xul/gwt/widgets/GwtTabWidget.java
@@ -28,7 +28,7 @@ public class GwtTabWidget extends HorizontalPanel {
     this.fullText = text;
     setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
     panel.setStyleName("pentaho-tabWidget"); //$NON-NLS-1$
-    Image leftCapImage = new Image(GWT.getModuleBaseURL() + "/images/spacer.gif");
+    Image leftCapImage = new Image(GWT.getModuleBaseURL() + "images/spacer.gif");
     leftCapImage.setStylePrimaryName("tab-spacer");
 
     setLabelText(text);


### PR DESCRIPTION
removed extraneous slash that was causing parsing errors while printing.
