### PR TITLE
[BISERVER-11723] 

### DIFF
--- a/pentaho-xul-gwt/src/org/pentaho/ui/xul/public/xul.css
+++ b/pentaho-xul-gwt/src/org/pentaho/ui/xul/public/xul.css
@@ -100,6 +100,7 @@ html, body{
     border: 1px solid #CBDDE8;
     float: left;
     cursor: default;
+    overflow: hidden;
 }
 
 /*


### PR DESCRIPTION
In IE 11 browser, on the Import Dialog when we browse for a csv file and if the file path is longer than the File name text box the path name is not truncated to appear within the text box but it appears on the dialog.
