### PR TITLE
[BACKLOG-4245] Adding onclick support to SwtLabel.

### DIFF
--- a/pentaho-xul-swt/src/org/pentaho/ui/xul/swt/tags/SwtLabel.java
+++ b/pentaho-xul-swt/src/org/pentaho/ui/xul/swt/tags/SwtLabel.java
@@ -19,8 +19,11 @@ package org.pentaho.ui.xul.swt.tags;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.pentaho.ui.xul.XulComponent;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.components.XulLabel;
@@ -31,32 +34,55 @@ public class SwtLabel extends SwtElement implements XulLabel {
   private static final long serialVersionUID = 5202737172518086153L;
 
   private boolean disabled;
+  private String onclick;
+  private Link link;
   CLabel cLabel;
   Label label;
 
   public SwtLabel( Element self, XulComponent parent, XulDomContainer container, String tagName ) {
     super( tagName );
 
-    String multi = ( self != null ) ? self.getAttributeValue( "multiline" ) : null;
-    if ( multi != null && multi.equals( "true" ) ) {
-      label = new Label( (Composite) parent.getManagedObject(), SWT.WRAP );
-      setManagedObject( label );
+    if ( self.getAttributeValue( "onclick" ) != null ) {
+      link = new Link( (Composite) parent.getManagedObject(), SWT.NONE );
+      link.addSelectionListener( new SelectionListener() {
+        public void widgetSelected( SelectionEvent selectionEvent ) {
+          invoke( onclick );
+        }
+
+        public void widgetDefaultSelected( SelectionEvent selectionEvent ) {
+          invoke( onclick );
+        }
+      } );
+      setManagedObject( link );
     } else {
-      cLabel = new CLabel( (Composite) parent.getManagedObject(), SWT.NONE );
-      setManagedObject( cLabel );
+      String multi = ( self != null ) ? self.getAttributeValue( "multiline" ) : null;
+      if ( multi != null && multi.equals( "true" ) ) {
+        label = new Label( (Composite) parent.getManagedObject(), SWT.WRAP );
+        setManagedObject( label );
+      } else {
+        cLabel = new CLabel( (Composite) parent.getManagedObject(), SWT.NONE );
+        setManagedObject( cLabel );
+      }
     }
   }
 
   /**
    * True parameter for bean-able attribute "value" (XUL attribute)
-   * 
+   *
    * @param text
    */
   public void setValue( String text ) {
     if ( text == null ) {
       text = "";
     }
-    if ( label != null ) {
+    if ( link != null ) {
+      // Wrap entire text in an anchor tag so it looks like a link. Only do this if an anchor is not provided so we can
+      // support something like "Click <a>here</a> for more information."
+      if ( !text.contains( "<a>" ) ) {
+        text = "<a>" + text + "</a>";
+      }
+      link.setText( text );
+    } else if ( label != null ) {
       label.setText( text );
       if ( getParent() != null ) {
         label.getShell().layout( true );
@@ -67,13 +93,13 @@ public class SwtLabel extends SwtElement implements XulLabel {
   }
 
   public String getValue() {
-    return ( label != null ) ? label.getText() : cLabel.getText();
+    return link != null ? link.getText() : ( label != null ) ? label.getText() : cLabel.getText();
   }
 
   /**
    * XUL's attribute is "disabled", thus this acts exactly the opposite of SWT. If the property is not available, then
    * the control is enabled.
-   * 
+   *
    * @return boolean true if the control is disabled.
    */
   public boolean isDisabled() {
@@ -82,7 +108,9 @@ public class SwtLabel extends SwtElement implements XulLabel {
 
   public void setDisabled( boolean disabled ) {
     this.disabled = disabled;
-    if ( label != null ) {
+    if ( link != null ) {
+      link.setEnabled( !disabled );
+    } else if ( label != null ) {
       if ( !label.isDisposed() ) {
         label.setEnabled( !disabled );
       }
@@ -91,4 +119,11 @@ public class SwtLabel extends SwtElement implements XulLabel {
     }
   }
 
+  public String getOnclick() {
+    return onclick;
+  }
+
+  public void setOnclick( String onclick ) {
+    this.onclick = onclick;
+  }
 }

--- a/pentaho-xul-swt/test-src/org/pentaho/ui/xul/test/swt/SwtLabelTest.java
+++ b/pentaho-xul-swt/test-src/org/pentaho/ui/xul/test/swt/SwtLabelTest.java
@@ -17,12 +17,16 @@
 
 package org.pentaho.ui.xul.test.swt;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.awt.GraphicsEnvironment;
 
 import org.dom4j.Document;
+import org.eclipse.swt.custom.CLabel;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -32,6 +36,7 @@ import org.pentaho.ui.xul.XulRunner;
 import org.pentaho.ui.xul.components.XulLabel;
 import org.pentaho.ui.xul.swt.SwtXulLoader;
 import org.pentaho.ui.xul.swt.SwtXulRunner;
+import org.pentaho.ui.xul.swt.tags.SwtLabel;
 
 public class SwtLabelTest {
 
@@ -74,7 +79,26 @@ public class SwtLabelTest {
     assertTrue( !label.isDisabled() );
     label.setDisabled( true );
     assertTrue( label.isDisabled() );
-
   }
+
+  @Test
+  public void testLink() {
+    SwtLabel swtLabel = (SwtLabel) container.getDocumentRoot().getElementById( "label-four" );
+    assertThat( swtLabel.getManagedObject(), instanceOf( org.eclipse.swt.widgets.Link.class ) );
+    assertThat( swtLabel.getOnclick(), equalTo( "doIt()" ) );
+  }
+
+  @Test
+  public void testMultilineLabel() {
+    SwtLabel swtLabel = (SwtLabel) container.getDocumentRoot().getElementById( "label-three" );
+    assertThat( swtLabel.getManagedObject(), instanceOf( org.eclipse.swt.widgets.Label.class ) );
+  }
+
+  @Test
+  public void testSinglelineLabel() {
+    SwtLabel swtLabel = (SwtLabel) container.getDocumentRoot().getElementById( "label-two" );
+    assertThat( swtLabel.getManagedObject(), instanceOf( CLabel.class ) );
+  }
+
 
 }

--- a/pentaho-xul-swt/test-src/resource/documents/labeltest.xul
+++ b/pentaho-xul-swt/test-src/resource/documents/labeltest.xul
@@ -6,7 +6,8 @@
 	<hbox id="label-box" orient="horizontal">
 		<label id="label-one" value="First Label" />
 		<label id="label-two" value="Second Label" />
-		<label id="label-three" value="Third Label" />
+		<label id="label-three" value="Third Label" multiline="true" />
+		<label id="label-four" value="Fourth Label" onclick="doIt()" />
 	</hbox>
 
 </window>


### PR DESCRIPTION
Needed to add a help link from the dataservices dialog in spoon.

This change brings over the SwtLabelOrLink class from big-data-plugin:
https://github.com/pentaho/big-data-plugin/commit/6fb8e8b459c6372ac1db60998a48668a1a5468df

@pentaho-nbaker 