### PR TITLE
[CLEANUP] Need to specify the versions of some eclipse dependencies in

### DIFF
--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -46,6 +46,16 @@
       <version>${jface.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.equinox.common</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.core.commands</artifactId>
+      <version>3.9.800</version>
+    </dependency>
+    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>${commons-collections.version}</version>


### PR DESCRIPTION
order to avoid pulling in Java 11 artifacts.
This commit is a cherry-pick from master 28afda65bed