### PR TITLE
[BACKLOG-37104] Basic responsive support for XUL/GWT base dialog classes

### DIFF
--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtConfirmBox.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtConfirmBox.java
@@ -12,27 +12,28 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.ui.xul.gwt.tags;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.pentaho.ui.xul.components.XulConfirmBox;
-import org.pentaho.ui.xul.dom.Element;
-import org.pentaho.ui.xul.gwt.GwtXulHandler;
-import org.pentaho.ui.xul.gwt.GwtXulParser;
-import org.pentaho.ui.xul.util.XulDialogCallback;
-
+import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.client.ui.Button;
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
+import org.pentaho.ui.xul.components.XulConfirmBox;
+import org.pentaho.ui.xul.dom.Element;
+import org.pentaho.ui.xul.gwt.GwtXulHandler;
+import org.pentaho.ui.xul.gwt.GwtXulParser;
+import org.pentaho.ui.xul.util.XulDialogCallback;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GwtConfirmBox extends GwtMessageBox implements XulConfirmBox {
 
@@ -89,7 +90,7 @@ public class GwtConfirmBox extends GwtMessageBox implements XulConfirmBox {
     acceptBtn.setText( acceptLabel );
     cancelBtn.setText( cancelLabel );
 
-    HorizontalPanel hp = new HorizontalPanel();
+    HorizontalPanel hp = new HorizontalFlexPanel();
     hp.add( acceptBtn );
     hp.setCellWidth( acceptBtn, "100%" );
     hp.setCellHorizontalAlignment( acceptBtn, hp.ALIGN_RIGHT );
@@ -100,7 +101,7 @@ public class GwtConfirmBox extends GwtMessageBox implements XulConfirmBox {
   @Override
   public Panel getDialogContents() {
 
-    VerticalPanel vp = new VerticalPanel();
+    VerticalPanel vp = new VerticalFlexPanel();
     Label lbl = new Label( getMessage() );
     vp.add( lbl );
     vp.setCellHorizontalAlignment( lbl, vp.ALIGN_CENTER );

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtDialog.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtDialog.java
@@ -17,17 +17,15 @@
 
 package org.pentaho.ui.xul.gwt.tags;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
+import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.ui.xul.XulComponent;
 import org.pentaho.ui.xul.XulDomContainer;
@@ -40,7 +38,8 @@ import org.pentaho.ui.xul.gwt.GwtXulParser;
 import org.pentaho.ui.xul.gwt.util.GenericDialog;
 import org.pentaho.ui.xul.util.Orient;
 
-import org.pentaho.gwt.widgets.client.utils.ElementUtils;
+import java.util.ArrayList;
+import java.util.List;
 
 public class GwtDialog extends GenericDialog implements XulDialog {
 
@@ -134,13 +133,13 @@ public class GwtDialog extends GenericDialog implements XulDialog {
       ignoreIndividualButtonAlign = true;
     }
 
-    HorizontalPanel buttonPanel = new HorizontalPanel();
-    HorizontalPanel leftButtonPanel = new HorizontalPanel();
-    HorizontalPanel centerButtonPanel = new HorizontalPanel();
-    HorizontalPanel rightButtonPanel = new HorizontalPanel();
-    rightButtonPanel.setStylePrimaryName( "buttonTable" );
-    centerButtonPanel.setStylePrimaryName( "buttonTable" );
-    leftButtonPanel.setStylePrimaryName( "buttonTable" );
+    HorizontalPanel buttonPanel = new HorizontalFlexPanel();
+    HorizontalPanel leftButtonPanel = new HorizontalFlexPanel();
+    HorizontalPanel centerButtonPanel = new HorizontalFlexPanel();
+    HorizontalPanel rightButtonPanel = new HorizontalFlexPanel();
+    rightButtonPanel.addStyleName( "buttonTable" );
+    centerButtonPanel.addStyleName( "buttonTable" );
+    leftButtonPanel.addStyleName( "buttonTable" );
 
     // keep track of the number in the left and right button cells. If they're not the same, add shims to fix the
     // center
@@ -192,7 +191,7 @@ public class GwtDialog extends GenericDialog implements XulDialog {
   @Override
   public Panel getDialogContents() {
 
-    VerticalPanel contentPanel = new VerticalPanel();
+    VerticalPanel contentPanel = new VerticalFlexPanel();
     contentPanel.setSpacing( 0 );
     container = contentPanel;
 

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtMessageBox.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtMessageBox.java
@@ -17,6 +17,7 @@
 
 package org.pentaho.ui.xul.gwt.tags;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.HTML;
@@ -24,6 +25,9 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.pentaho.gwt.widgets.client.dialogs.DialogBox;
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
 import org.pentaho.ui.xul.components.XulMessageBox;
 import org.pentaho.ui.xul.dom.Element;
 import org.pentaho.ui.xul.gwt.GwtXulHandler;
@@ -66,15 +70,33 @@ public class GwtMessageBox extends GenericDialog implements XulMessageBox {
     } );
 
     acceptBtn.setStylePrimaryName( "pentaho-button" );
+
+    // ARIA
+    // Override role from "dialog" to "alertdialog".
+    setAriaRole( Roles.getAlertdialogRole().getName() );
   }
 
   protected GwtMessageBox( String elementName ) {
     super( elementName );
+
+    // ARIA
+    // Override role from "dialog" to "alertdialog".
+    setAriaRole( Roles.getAlertdialogRole().getName() );
+  }
+
+  @Override
+  protected DialogBox createManagedDialog() {
+    DialogBox dialog = super.createManagedDialog();
+    dialog.setResponsive( true );
+    dialog.setWidthCategory( DialogBox.DialogWidthCategory.TEXT );
+    dialog.setMinimumHeightCategory( DialogBox.DialogMinimumHeightCategory.CONTENT );
+
+    return dialog;
   }
 
   @Override
   public Panel getButtonPanel() {
-    HorizontalPanel hp = new HorizontalPanel();
+    HorizontalPanel hp = new HorizontalFlexPanel();
     acceptBtn.setText( this.acceptLabel );
     hp.add( acceptBtn );
     hp.setCellWidth( acceptBtn, "100%" );
@@ -85,7 +107,7 @@ public class GwtMessageBox extends GenericDialog implements XulMessageBox {
   @Override
   public Panel getDialogContents() {
 
-    VerticalPanel vp = new VerticalPanel();
+    VerticalPanel vp = new VerticalFlexPanel();
     String[] lines = message.split( "\n", -1 );
     StringBuffer sb = new StringBuffer();
     for ( String line : lines ) {

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtPromptBox.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtPromptBox.java
@@ -12,23 +12,16 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.ui.xul.gwt.tags;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.pentaho.ui.xul.components.XulPromptBox;
-import org.pentaho.ui.xul.dom.Element;
-import org.pentaho.ui.xul.gwt.GwtXulHandler;
-import org.pentaho.ui.xul.gwt.GwtXulParser;
-import org.pentaho.ui.xul.util.XulDialogCallback;
-
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
@@ -36,7 +29,16 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.client.ui.Button;
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
+import org.pentaho.ui.xul.components.XulPromptBox;
+import org.pentaho.ui.xul.dom.Element;
+import org.pentaho.ui.xul.gwt.GwtXulHandler;
+import org.pentaho.ui.xul.gwt.GwtXulParser;
+import org.pentaho.ui.xul.util.XulDialogCallback;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GwtPromptBox extends GwtMessageBox implements XulPromptBox {
 
@@ -63,6 +65,11 @@ public class GwtPromptBox extends GwtMessageBox implements XulPromptBox {
 
   public GwtPromptBox() {
     super( ELEMENT_NAME );
+
+    // ARIA
+    // Revert back role to "dialog".
+    setAriaRole( Roles.getDialogRole().getName() );
+
     textbox.setWidth( "90%" );
     textbox.addKeyDownHandler( new KeyDownHandler() {
       public void onKeyDown( KeyDownEvent event ) {
@@ -120,7 +127,7 @@ public class GwtPromptBox extends GwtMessageBox implements XulPromptBox {
     acceptBtn.setText( acceptLabel );
     cancelBtn.setText( cancelLabel );
 
-    HorizontalPanel hp = new HorizontalPanel();
+    HorizontalPanel hp = new HorizontalFlexPanel();
     hp.add( acceptBtn );
     hp.setCellWidth( acceptBtn, "100%" );
     hp.setCellHorizontalAlignment( acceptBtn, hp.ALIGN_RIGHT );
@@ -131,7 +138,7 @@ public class GwtPromptBox extends GwtMessageBox implements XulPromptBox {
   @Override
   public Panel getDialogContents() {
 
-    VerticalPanel vp = new VerticalPanel();
+    VerticalPanel vp = new VerticalFlexPanel();
     Label lbl = new Label( getMessage() );
     lbl.addStyleName( "promptBoxLabel" );
     vp.add( lbl );

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/util/GenericDialog.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/util/GenericDialog.java
@@ -17,10 +17,12 @@
 
 package org.pentaho.ui.xul.gwt.util;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.pentaho.gwt.widgets.client.dialogs.DialogBox;
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
 import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
 import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
@@ -39,21 +41,17 @@ public abstract class GenericDialog extends AbstractGwtXulContainer {
   // requested height is adjusted by this value.
   private static final int HEADER_HEIGHT = 32;
 
-  private static final String ARIA_ROLE_DIALOG = "dialog";
-  private static final String ARIA_ROLE_ALERTDIALOG = "alertdialog";
   private static final String ATTRIBUTE_ARIA_DESCRIBEDBY = "pen:aria-describedby";
 
   public GenericDialog( String tagName ) {
     super( tagName );
 
     // Default ARIA role.
-    setAriaRole( ARIA_ROLE_DIALOG );
+    setAriaRole( Roles.getDialogRole().getName() );
   }
 
-  private void createDialog() {
-    dialog = new DialogBox();
-    dialog.addStyleName( "pentaho-gwt-xul" );
-    dialog.setWidget( contents );
+  protected DialogBox createManagedDialog() {
+    return new DialogBox();
   }
 
   public void hide() {
@@ -66,8 +64,12 @@ public abstract class GenericDialog extends AbstractGwtXulContainer {
     // Instantiation is delayed to prevent errors with the underlying GWT's not being able to calculate available
     // size, in the case that the GWT app has been loaded into an iframe that's not visible.
     if ( dialog == null ) {
-      createDialog();
+      dialog = createManagedDialog();
+      dialog.addStyleName( "pentaho-xul-gwt" );
+      dialog.addStyleName( "pentaho-xul-" + getName() );
+      dialog.setWidget( contents );
     }
+
     dialog.setText( title );
     dialog.setAriaRole( getAriaRole() );
 
@@ -79,7 +81,7 @@ public abstract class GenericDialog extends AbstractGwtXulContainer {
     Panel dialogContents = getDialogContents();
     dialogContents.setSize( "100%", "100%" );
 
-    dialogContents.setStyleName( "dialog-content" ); //$NON-NLS-1$
+    dialogContents.addStyleName( "dialog-content" ); //$NON-NLS-1$
 
     panel.add( dialogContents );
     panel.setCellHeight( dialogContents, "100%" );
@@ -103,10 +105,11 @@ public abstract class GenericDialog extends AbstractGwtXulContainer {
     dialog.setAriaDescribedBy( describedBy );
 
     Panel buttonPanel = this.getButtonPanel();
+    buttonPanel.addStyleName( "inner-button-wrapper" );
     buttonPanel.setWidth( "100%" );
 
-    HorizontalPanel buttonPanelWrapper = new HorizontalPanel();
-    buttonPanelWrapper.setStyleName( "button-panel" ); //$NON-NLS-1$
+    HorizontalPanel buttonPanelWrapper = new HorizontalFlexPanel();
+    buttonPanelWrapper.addStyleName( "button-panel" ); //$NON-NLS-1$
     buttonPanelWrapper.add( buttonPanel );
     buttonPanelWrapper.setWidth( "100%" ); //$NON-NLS-1$
     buttonPanelWrapper.setCellWidth( buttonPanel, "100%" );
@@ -152,10 +155,11 @@ public abstract class GenericDialog extends AbstractGwtXulContainer {
   }
 
   protected boolean isAriaRoleAlertDialog() {
-    return ARIA_ROLE_ALERTDIALOG.equals( getAriaRole() );
+    return Roles.getAlertdialogRole().getName().equals( getAriaRole() );
   }
 
   // region ariaDescribedBy attribute
+
   /**
    * Gets the identifier of the ARIA description element.
    */


### PR DESCRIPTION
- GenericDialog and GwtDialog
- GwtMessageBox, GwtConfirmBox, GwtPromptBox
- For now, allows dialog sub-classes to be responsive

@pentaho/wcag, please, review.

Part of PR set: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/873