### PR TITLE
[BACKLOG-37101] GWTTree**.java - Functional images don't provide text…

### DIFF
--- a/core/src/main/java/org/pentaho/ui/xul/components/XulTreeCol.java
+++ b/core/src/main/java/org/pentaho/ui/xul/components/XulTreeCol.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.ui.xul.components;
@@ -114,4 +114,12 @@ public interface XulTreeCol extends XulComponent {
   public String getClassnameBinding();
 
   public void setClassnameBinding( String classname );
+
+  default String getAlttextBinding() {
+    throw new UnsupportedOperationException( "getAltTextBinding() not implemented" );
+  }
+
+  default void setAlttextBinding( String altText ) {
+    throw new UnsupportedOperationException( "setAltTextBinding( altText ) not implemented" );
+  }
 }

--- a/core/src/main/java/org/pentaho/ui/xul/containers/XulTreeItem.java
+++ b/core/src/main/java/org/pentaho/ui/xul/containers/XulTreeItem.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.ui.xul.containers;
@@ -54,4 +54,12 @@ public interface XulTreeItem extends XulContainer {
   public void setClassname( String classname );
 
   public String getClassname();
+
+  public default void setAltText( String altText ) {
+    throw new UnsupportedOperationException( "setAltText( altText ) not implemented" );
+  }
+
+  public default String getAltText() {
+    throw new UnsupportedOperationException( "getAltText() not implemented" );
+  }
 }

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTreeCol.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTreeCol.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.ui.xul.gwt.tags;
@@ -44,6 +44,7 @@ public class GwtTreeCol extends AbstractGwtXulComponent implements XulTreeCol {
   private boolean sortActive = false;
   private String sortDirection = null;
   private String classnameBinding;
+  private String alttextBinding;
 
   public static void register() {
     GwtXulParser.registerHandler( "treecol", new GwtXulHandler() {
@@ -80,6 +81,10 @@ public class GwtTreeCol extends AbstractGwtXulComponent implements XulTreeCol {
     String classname = srcEle.getAttribute( "pen:classnamebinding" ); //$NON-NLS-1$
     if ( !StringUtils.isEmpty( classname ) ) {
       setClassnameBinding( classname );
+    }
+
+    if ( !StringUtils.isEmpty( srcEle.getAttribute( "pen:alttextbinding" ) ) ) {
+      setAlttextBinding( srcEle.getAttribute( "pen:alttextbinding" ) ); //$NON-NLS-1$
     }
   }
 
@@ -283,4 +288,15 @@ public class GwtTreeCol extends AbstractGwtXulComponent implements XulTreeCol {
     this.classnameBinding = classnameBinding;
   }
 
+  @Override
+  public String getAlttextBinding() {
+    return alttextBinding;
+  }
+
+  @Override
+  public void setAlttextBinding( String alttext ) {
+    this.alttextBinding = alttext;
+  }
+
 }
+

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTreeItem.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTreeItem.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.ui.xul.gwt.tags;
@@ -38,6 +38,7 @@ public class GwtTreeItem extends AbstractGwtXulContainer implements XulTreeItem 
   private String command;
   private String jscommand;
   private String classname;
+  private String alttext;
 
   public static void register() {
     GwtXulParser.registerHandler( "treeitem", new GwtXulHandler() {
@@ -191,5 +192,19 @@ public class GwtTreeItem extends AbstractGwtXulContainer implements XulTreeItem 
     String oldClassname = this.classname;
     this.classname = classname;
     firePropertyChange( "classname", oldClassname, classname ); //$NON-NLS-1$
+  }
+
+  @Bindable
+  @Override
+  public String  getAltText() {
+    return this.alttext;
+  }
+
+  @Bindable
+  @Override
+  public void setAltText( String altText ) {
+    String oldAltText = this.alttext;
+    this.alttext = altText;
+    firePropertyChange( "altText", oldAltText, altText ); //$NON-NLS-1$
   }
 }

--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/util/ImageUtil.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/util/ImageUtil.java
@@ -31,7 +31,9 @@ import java.util.List;
  */
 public class ImageUtil {
 
-  // WCAG 2.1 default value for attribute 'alt' when image doesn't have alternative text
+  /**
+   * WCAG 2.1 default value for attribute 'alt' when image doesn't have alternative text
+   */
   protected static final String DEFAULT_IMAGE_ALT_WCAG_TEXT = "";
 
   public static final String ATTRIBUTE_PEN_IMAGE_ALT_TEXT = "pen:imagealttext";


### PR DESCRIPTION
… alternative - GWT based Images

 - logic to parse "pen:tooltipbinding" for <treecol>
 - added  #getAltText() and #setAltText()
 - add logic to set image altText for tree nodes GwtTree#createNode()
 
 1/3 Pull requests:

- https://github.com/pentaho/modeler/pull/376
- https://github.com/pentaho/data-access/pull/1194
- https://github.com/pentaho/pentaho-commons-xul/pull/226

see demo and explanation at: https://hv-eng.atlassian.net/browse/BACKLOG-37101?focusedCommentId=1743972