### PR TITLE
[BACKLOG-38285] - Fix for incorrect double selection in "Manage Data Sources" wizard

### DIFF
--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTree.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTree.java
@@ -1128,7 +1128,6 @@ public class GwtTree extends AbstractGwtXulContainer implements XulTree, Resizab
       // this only works after the table has been materialized
       return;
     }
-    updateSelectedRowsInTable();
     int[] prevSelected = selectedRows;
     selectedRows = rows;
 


### PR DESCRIPTION
Please review @pentaho/wcag