### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/gwt/assembly/pom.xml
+++ b/gwt/assembly/pom.xml
@@ -40,11 +40,11 @@
       <artifactId>GWT-FX</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>
@@ -94,7 +94,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
         <executions>
           <execution>
             <goals>

--- a/gwt/impl/pom.xml
+++ b/gwt/impl/pom.xml
@@ -16,12 +16,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>${gwt.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <version>${gwt.version}</version>
     </dependency>

--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -32,7 +32,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <exclusions>
           <exclusion>
@@ -42,7 +42,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-dev</artifactId>
         <exclusions>
           <exclusion>

--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -16,7 +16,11 @@
   </parent>
 
   <properties>
-    <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
+    <org.eclipse.swt.gtk.linux.x86.version>3.108.0</org.eclipse.swt.gtk.linux.x86.version>
+    <org.eclipse.swt.gtk.linux.x86_64.version>3.108.0</org.eclipse.swt.gtk.linux.x86_64.version>
+    <org.eclipse.swt.win32.win32.x86_64.version>3.115.100</org.eclipse.swt.win32.win32.x86_64.version>
+    <org.eclipse.swt.cocoa.macosx.x86_64.version>3.115.100</org.eclipse.swt.cocoa.macosx.x86_64.version>
+    <org.eclipse.swt.cocoa.macosx.aarch64.version>3.122.0</org.eclipse.swt.cocoa.macosx.aarch64.version>
     <jface.version>3.22.0</jface.version>
     <commons-collections.version>3.2.2</commons-collections.version>
   </properties>
@@ -70,7 +74,41 @@
 
   <profiles>
     <profile>
-      <id>unix-swt</id>
+      <id>unix-swt-x86</id>
+      <activation>
+        <os>
+          <family>unix</family>
+          <name>Linux</name>
+          <arch>x86</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt.gtk.linux.x86</artifactId>
+          <version>${org.eclipse.swt.gtk.linux.x86.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>unix-swt-x86_64</id>
+      <activation>
+        <os>
+          <family>unix</family>
+          <name>Linux</name>
+          <arch>amd64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
+          <version>${org.eclipse.swt.gtk.linux.x86_64.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>unix-swt-fallback</id>
       <activation>
         <os>
           <family>unix</family>
@@ -79,9 +117,9 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.eclipse.swt</groupId>
+          <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-          <version>${org.eclipse.swt.version}</version>
+          <version>${org.eclipse.swt.gtk.linux.x86_64.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -94,17 +132,18 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.eclipse.swt</groupId>
+          <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-          <version>${org.eclipse.swt.version}</version>
+          <version>${org.eclipse.swt.win32.win32.x86_64.version}</version>
         </dependency>
       </dependencies>
     </profile>
     <profile>
-      <id>mac-swt</id>
+      <id>mac-swt-x86_64</id>
       <activation>
         <os>
           <family>mac</family>
+          <arch>x86_64</arch>
         </os>
       </activation>
       <properties>
@@ -112,9 +151,28 @@
       </properties>
       <dependencies>
         <dependency>
-          <groupId>org.eclipse.swt</groupId>
+          <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
-          <version>${org.eclipse.swt.version}</version>
+          <version>${org.eclipse.swt.cocoa.macosx.x86_64.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>mac-swt-aarch64</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <maven-surefire-plugin.argLine>-XstartOnFirstThread</maven-surefire-plugin.argLine>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt.cocoa.macosx.aarch64</artifactId>
+          <version>${org.eclipse.swt.cocoa.macosx.aarch64.version}</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `pom.xml` files to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, and `gwt-dev` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization.

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.

SWT updates:
* Updated SWT version properties in `swt/pom.xml` to use more recent and architecture-specific versions, supporting aarch64 Mac platforms.
* Refactored SWT profiles in `swt/pom.xml` to split platform and architecture combinations into separate profiles (`unix-swt-x86`, `unix-swt-x86_64`, `mac-swt-x86_64`, `mac-swt-aarch64`, etc.), improving build reliability on different systems. These versions are on pair with the ones used in other Pentaho components, like pentaho/pentaho-kettle.