### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/gwt/impl/pom.xml
+++ b/gwt/impl/pom.xml
@@ -67,13 +67,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>${bytebuddy.version}</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>${bytebuddy-agent.version}</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
     <license.licenseName>lgpl_v2_1</license.licenseName>
     <mockito-core.version>3.12.4</mockito-core.version>
     <junit.version>4.13.2</junit.version>
-    <bytebuddy.version>1.14.12</bytebuddy.version>
-    <bytebuddy-agent.version>1.14.12</bytebuddy-agent.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This pull request updates how Byte Buddy dependencies are versioned in the Maven configuration. Instead of using two separate properties for `byte-buddy` and `byte-buddy-agent`, it now uses a single property for both.

Dependency management simplification:

* In `gwt/impl/pom.xml`, both the `byte-buddy` and `byte-buddy-agent` dependencies now use the single `${byte-buddy.version}` property for their versions, instead of separate properties.
* In `pom.xml`, the separate `bytebuddy.version` and `bytebuddy-agent.version` properties were removed, consolidating version management for Byte Buddy dependencies.