### PR TITLE
feat: ensure setVisible is applied to textbox [PRD-6183]

### DIFF
--- a/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTextbox.java
+++ b/gwt/impl/src/main/java/org/pentaho/ui/xul/gwt/tags/GwtTextbox.java
@@ -178,6 +178,7 @@ public class GwtTextbox extends AbstractGwtXulComponent implements XulTextbox {
     }
     textBox.setText( getValue() );
     textBox.setEnabled( !this.isDisabled() );
+    textBox.setVisible( this.isVisible() );
     setupListeners();
   }
 
@@ -351,5 +352,12 @@ public class GwtTextbox extends AbstractGwtXulComponent implements XulTextbox {
 
   public void setCommand( String command ) {
     throw new RuntimeException( "command not implemented on textbox" );
+  }
+
+  @Bindable
+  @Override
+  public void setVisible( boolean visible ) {
+    super.setVisible( visible );
+    textBox.setVisible( visible );
   }
 }

--- a/swt/src/main/java/org/pentaho/ui/xul/swt/SwtElement.java
+++ b/swt/src/main/java/org/pentaho/ui/xul/swt/SwtElement.java
@@ -116,9 +116,9 @@ public class SwtElement extends AbstractXulComponent {
             && !( ( (Control) mo ).getParent() instanceof ScrolledComposite ) ) {
             ( (Control) mo ).setParent( (Composite) getManagedObject() );
           }
-        } else if ( mo instanceof Viewer ) {
-          if ( ( (Viewer) mo ).getControl() != getManagedObject() && getManagedObject() instanceof Composite ) {
-            ( (Viewer) mo ).getControl().setParent( (Composite) getManagedObject() );
+        } else if ( mo instanceof Viewer viewer ) {
+          if ( viewer.getControl() != getManagedObject() && getManagedObject() instanceof Composite ) {
+            viewer.getControl().setParent( (Composite) getManagedObject() );
           }
         }
       }
@@ -129,13 +129,20 @@ public class SwtElement extends AbstractXulComponent {
       layout();
       ( (XulComponent) e ).onDomReady();
     }
-
+    if (comp.getManagedObject() instanceof Viewer viewer ) {
+    viewer.getControl().setVisible( true );
+    }
   }
 
   public void addChildAt( Element c, int pos ) {
     super.addChildAt( c, pos );
     if ( initialized ) {
       layout();
+    }
+    XulComponent comp = (XulComponent) c;
+    Object mo = comp.getManagedObject();
+    if ( mo instanceof Viewer viewer && viewer.getControl() != null) {
+      viewer.getControl().setVisible( true );
     }
   }
 
@@ -148,6 +155,10 @@ public class SwtElement extends AbstractXulComponent {
         Widget thisWidget = (Widget) comp.getManagedObject();
         if ( thisWidget != null && !thisWidget.isDisposed() ) {
           thisWidget.dispose();
+        }
+      } else if (comp.getManagedObject() instanceof Viewer viewer) {
+        if ( viewer.getControl() != null && !viewer.getControl().isDisposed()) {
+          viewer.getControl().setVisible( false );
         }
       }
     }


### PR DESCRIPTION
Ensure `isVisible` attribute is being applied to the underlying `textbox` for GWT and SWT cases.

Related PR: https://github.com/pentaho/mql-editor/pull/89