### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -14,7 +14,6 @@
   <name>Commons XUL GWT</name>
   
   <properties>
-    <validation-api.version>1.0.0.GA</validation-api.version>
     <commons-gwt.version>10.2.0.0-SNAPSHOT</commons-gwt.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
   </properties>
@@ -75,29 +74,6 @@
         <groupId>com.google.code.gwtx</groupId>
         <artifactId>gwtx</artifactId>
         <version>${gwtx.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${validation-api.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${validation-api.version}</version>
-        <classifier>sources</classifier>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2