### PR TITLE
CVE fix: CVE-2023-4218 in org.eclipse.platform:org.eclipse.jface

### DIFF
--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -21,7 +21,8 @@
     <org.eclipse.swt.win32.win32.x86_64.version>3.115.100</org.eclipse.swt.win32.win32.x86_64.version>
     <org.eclipse.swt.cocoa.macosx.x86_64.version>3.115.100</org.eclipse.swt.cocoa.macosx.x86_64.version>
     <org.eclipse.swt.cocoa.macosx.aarch64.version>3.122.0</org.eclipse.swt.cocoa.macosx.aarch64.version>
-    <jface.version>3.22.0</jface.version>
+    <!-- Eclipse UI libs bumped together to remediate CVE-2023-4218 (jface XXE); aligned with pentaho-kettle PPP-6529 (jface 3.31.0 / commands 3.12.100 / common 3.18.0). jface 3.31.0 requires equinox.common [3.18.0,4.0.0). -->
+    <jface.version>3.31.0</jface.version>
     <commons-collections.version>3.2.2</commons-collections.version>
   </properties>
 
@@ -51,12 +52,12 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.equinox.common</artifactId>
-      <version>3.14.0</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.commands</artifactId>
-      <version>3.9.800</version>
+      <version>3.12.100</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/swt/src/test/java/org/pentaho/ui/xul/test/swt/JFaceCveRegressionTest.java
+++ b/swt/src/test/java/org/pentaho/ui/xul/test/swt/JFaceCveRegressionTest.java
@@ -13,12 +13,14 @@
 
 package org.pentaho.ui.xul.test.swt;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.Manifest;
 
 import org.junit.Test;
@@ -38,15 +40,20 @@ public class JFaceCveRegressionTest {
 
   @Test
   public void jfaceBundleIsAtOrAboveCveFixedVersion() throws Exception {
-    String bundleVersion = resolveJFaceBundleVersion();
-    assertNotNull( "org.eclipse.jface bundle was not found on the classpath", bundleVersion );
-    assertTrue(
-      "Vulnerable org.eclipse.jface " + bundleVersion
-        + " is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
-      compareToMinimum( bundleVersion ) >= 0 );
+    List<String> bundleVersions = resolveJFaceBundleVersions();
+    assertFalse( "org.eclipse.jface bundle was not found on the classpath", bundleVersions.isEmpty() );
+    // Check EVERY jface bundle on the classpath (order-independent): if any copy is below the
+    // fixed line the guard must fail, regardless of which one Maven resolution would win.
+    for ( String bundleVersion : bundleVersions ) {
+      assertTrue(
+        "Vulnerable org.eclipse.jface " + bundleVersion + " (all found: " + bundleVersions
+          + ") is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
+        compareToMinimum( bundleVersion ) >= 0 );
+    }
   }
 
-  private static String resolveJFaceBundleVersion() throws Exception {
+  private static List<String> resolveJFaceBundleVersions() throws Exception {
+    List<String> versions = new ArrayList<>();
     Enumeration<URL> manifests =
       JFaceCveRegressionTest.class.getClassLoader().getResources( "META-INF/MANIFEST.MF" );
     while ( manifests.hasMoreElements() ) {
@@ -54,11 +61,14 @@ public class JFaceCveRegressionTest {
         Manifest manifest = new Manifest( in );
         String symbolicName = manifest.getMainAttributes().getValue( "Bundle-SymbolicName" );
         if ( symbolicName != null && "org.eclipse.jface".equals( symbolicName.split( ";" )[ 0 ].trim() ) ) {
-          return manifest.getMainAttributes().getValue( "Bundle-Version" );
+          String version = manifest.getMainAttributes().getValue( "Bundle-Version" );
+          if ( version != null ) {
+            versions.add( version );
+          }
         }
       }
     }
-    return null;
+    return versions;
   }
 
   private static int compareToMinimum( String actualVersion ) {

--- a/swt/src/test/java/org/pentaho/ui/xul/test/swt/JFaceCveRegressionTest.java
+++ b/swt/src/test/java/org/pentaho/ui/xul/test/swt/JFaceCveRegressionTest.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.ui.xul.test.swt;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+
+/**
+ * Regression guard for CVE-2023-4218 (Eclipse JFace XXE, CWE-611).
+ *
+ * <p>Fails if the {@code org.eclipse.jface} bundle resolved on the classpath is older than the
+ * first fixed version on the current line (3.29.0). This encodes the remediation invariant so the
+ * vulnerable 3.22.0 cannot silently creep back via {@code jface.version}. RED on 3.22.0, GREEN on
+ * 3.31.0.</p>
+ */
+public class JFaceCveRegressionTest {
+
+  /** First fixed version on the current JFace line for CVE-2023-4218. */
+  private static final int[] MIN_FIXED_VERSION = { 3, 29, 0 };
+
+  @Test
+  public void jfaceBundleIsAtOrAboveCveFixedVersion() throws Exception {
+    String bundleVersion = resolveJFaceBundleVersion();
+    assertNotNull( "org.eclipse.jface bundle was not found on the classpath", bundleVersion );
+    assertTrue(
+      "Vulnerable org.eclipse.jface " + bundleVersion
+        + " is below the CVE-2023-4218 fixed line (3.29.0); bump jface.version.",
+      compareToMinimum( bundleVersion ) >= 0 );
+  }
+
+  private static String resolveJFaceBundleVersion() throws Exception {
+    Enumeration<URL> manifests =
+      JFaceCveRegressionTest.class.getClassLoader().getResources( "META-INF/MANIFEST.MF" );
+    while ( manifests.hasMoreElements() ) {
+      try ( InputStream in = manifests.nextElement().openStream() ) {
+        Manifest manifest = new Manifest( in );
+        String symbolicName = manifest.getMainAttributes().getValue( "Bundle-SymbolicName" );
+        if ( symbolicName != null && "org.eclipse.jface".equals( symbolicName.split( ";" )[ 0 ].trim() ) ) {
+          return manifest.getMainAttributes().getValue( "Bundle-Version" );
+        }
+      }
+    }
+    return null;
+  }
+
+  private static int compareToMinimum( String actualVersion ) {
+    String[] parts = actualVersion.split( "\\." );
+    for ( int i = 0; i < MIN_FIXED_VERSION.length; i++ ) {
+      int actual = i < parts.length ? leadingInt( parts[ i ] ) : 0;
+      if ( actual != MIN_FIXED_VERSION[ i ] ) {
+        return actual - MIN_FIXED_VERSION[ i ];
+      }
+    }
+    return 0;
+  }
+
+  private static int leadingInt( String value ) {
+    int end = 0;
+    while ( end < value.length() && Character.isDigit( value.charAt( end ) ) ) {
+      end++;
+    }
+    return end == 0 ? 0 : Integer.parseInt( value.substring( 0, end ) );
+  }
+}


### PR DESCRIPTION
## CVE fix: CVE-2023-4218 in org.eclipse.platform:org.eclipse.jface

Tracking: [PPP-6529](https://pentaho-eng.atlassian.net/browse/PPP-6529)
Advisory: CVE-2023-4218 / GHSA-j24h-xcpc-9jw8 -- Medium (CWE-611, XXE)
Change: `org.eclipse.platform:org.eclipse.jface` 3.22.0 -> 3.31.0 (in `swt/pom.xml`)

Leftover companion to pentaho/pentaho-metadata-editor-ee#206. `commons-xul-swt` is a shared library whose compile-scope jface declared the vulnerable 3.22.0, leaking it transitively to consumers that don't override it. Aligns commons-xul with the platform baseline set by pentaho-kettle PPP-6529.

### Why 3.31.0 (not 3.29.0)
Aligned with **pentaho-kettle PPP-6529** (PR #10537): `jface 3.31.0 / core.commands 3.12.100 / equinox.common 3.18.0`. `equinox.common` **must** move to >= 3.18.0 because `org.eclipse.jface 3.31.0` requires `org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"`.

Changes:
- `swt/pom.xml` (+4/-3): `jface.version` 3.22.0->3.31.0, `org.eclipse.equinox.common` literal 3.14.0->3.18.0, `org.eclipse.core.commands` literal 3.9.800->3.12.100
- New test `swt/src/test/java/org/pentaho/ui/xul/test/swt/JFaceCveRegressionTest.java`

### Dependency tree (before -> after), `swt` module
Before: `org.eclipse.jface:3.22.0`, `core.commands:3.9.800`, `equinox.common:3.14.0`
After (BUILD SUCCESS, no 3.22.0): `org.eclipse.jface:3.31.0`, `core.commands:3.12.100`, `equinox.common:3.18.0`

Note: `commons-xul-swt` does not wildcard-exclude jface's transitives (pre-existing), so jface now also pulls newer `org.eclipse.swt:3.124.100` / `org.eclipse.osgi:3.18.500` transitively (same shape as jface 3.22.0 did, just newer). Product consumers (PME/kettle) exclude and redeclare their own SWT, so the ripple is contained. Change kept minimal (no new exclusions).

### Tests
- `commons-xul-swt` compiles clean against 3.31.0.
- Added a **RED-first regression guard** (`JFaceCveRegressionTest`) asserting the resolved `org.eclipse.jface` bundle is at/above the CVE-2023-4218 fixed line (3.29.0). Verified locally: **fails on 3.22.0**, **passes on 3.31.0**.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.
